### PR TITLE
update tomcat version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -127,7 +127,7 @@
     <version.shrinkwrap.descriptor>2.0.0-alpha-7</version.shrinkwrap.descriptor>
     <version.shrinkwrap.shrinkwrap>1.2.2</version.shrinkwrap.shrinkwrap>
 
-    <tomcat.version>8.5.34</tomcat.version>
+    <tomcat.version>8.5.3TT</tomcat.version>
 
     <cxf.version>3.1.6</cxf.version>
     <ehcache.version>2.9.0</ehcache.version>

--- a/pom.xml
+++ b/pom.xml
@@ -127,7 +127,7 @@
     <version.shrinkwrap.descriptor>2.0.0-alpha-7</version.shrinkwrap.descriptor>
     <version.shrinkwrap.shrinkwrap>1.2.2</version.shrinkwrap.shrinkwrap>
 
-    <tomcat.version>8.5.3</tomcat.version>
+    <tomcat.version>8.5.34</tomcat.version>
 
     <cxf.version>3.1.6</cxf.version>
     <ehcache.version>2.9.0</ehcache.version>

--- a/tomee/tomee-webapp/src/main/webapp/app.js
+++ b/tomee/tomee-webapp/src/main/webapp/app.js
@@ -62,7 +62,7 @@ $(function () {
             $('.ux-server-ready-panel').removeClass('ux-hidden');
             var providerLink = $($('.ux-provider-url').get(0));
             providerLink.attr('href', window.location.href + 'ejb');
-            providerLink.html(window.location.href + 'ejb');
+            providerLink.html(window.location.origin + window.location.pathname + 'ejb');
         } else if (systemStatus.status === 'REBOOT_REQUIRED') {
             $('.ux-installer-reboot-panel').removeClass('ux-hidden');
         } else {


### PR DESCRIPTION
- [x] CVE-2016-6817 - Tomcat 
- [x] CVE-2018-1336 - Tomcat
- [ ] CVE-2017-12624 - CXF
- [x] CVE-2015-3208 -  ActiveMQ Artemis 
- [ ] CVE-2016-8739 - CXF
- [x] CVE-2015-0254-  ActiveMQ Artemis 
- [x] CVE-2017-5651 - Tomcat
- [x] CVE-2018-8014 - Tomcat
- [x] CVE-2015-7559 - ActiveMQ
- [X] CVE-2016-6796 -  Tomcat
- [x] CVE-2017-5647 - Bouncy Castle JCE
- [X] CVE-2016-1000343 - Tomcat
- [X] CVE-2016-6797 - Tomcat
- [x] CVE-2016-1000340 - Bouncy Castle JCE
- [x] CVE-2017-5664 - Bouncy Castle JCE
- [X] CVE-2017-5664 - Tomcat JSP
- [x] CVE-2016-1000338 - Bouncy Castle JCE
- [X] CVE-2016-8745 - Tomcat
- [X] CVE-2017-5656 - CXF
- [x] CVE-2018-1000180 - Bouncy Castle JCE
- [X] CVE-2017-7675 - Tomcat
- [X] CVE-2016-5018 - Tomcat
- [ ] CVE-2017-3156 - CXF
- [x] CVE-2016-1000344 - Bouncy Castle JCE
- [x] CVE-2016-1000352 - Bouncy Castle JCE
- [ ] CVE-2018-8039 - CXF
- [X] CVE-2016-6816 - Tomcat
- [X] CVE-2018-8034 - Tomcat
- [X] CVE-2018-1305 - Tomcat
- [ ] CVE-2016-6812 - CXF
- [x]  CVE-2018-8031 - TomEE
- [x]  CVE-2016-1000346  - Bouncy Castle JCE
- [x]  CVE-2016-1000341  - Bouncy Castle JCE
- [X] CVE-2018-1304 - Tomcat
- [X] CVE-2016-6794 - Tomcat
- [x]  CVE-2016-1000339  - Bouncy Castle JCE
- [x]  sonatype-2015-0270 - TomEE
- [x]  CVE-2018-8037 - Tomcat
- [x]  CVE-2017-7674 - Tomcat

Id depdends: https://github.com/tomitribe/tomcat85/pull/1






